### PR TITLE
Update HubSpotException.php

### DIFF
--- a/src/Fungku/HubSpot/API/HubSpotException.php
+++ b/src/Fungku/HubSpot/API/HubSpotException.php
@@ -26,4 +26,4 @@ namespace Fungku\HubSpot\API;
  * @author Christopher Hoult <chris.hoult@datasift.com>
  * @see https://github.com/chrishoult
  */
-class HubSpotException extends Exception {}
+class HubSpotException extends \Exception {}


### PR DESCRIPTION
adding a \ in front of Exception {} so that the exception class can be found
